### PR TITLE
feat: add an ARM64 image

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,1 @@
-parallelDockerUpdatecli([imageName: 'matomo', rebuildImageOnPeriodicJob: false])
+parallelDockerUpdatecli([imageName: 'matomo', rebuildImageOnPeriodicJob: false, buildDockerConfig : [targetplatforms: 'linux/amd64,linux/arm64']])


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3602 and https://github.com/jenkins-infra/helpdesk/issues/3619

We want to run matomo on arm64 nodes: let's start by building its image for both x86 and arm64