### PR TITLE
chore(Jenkinsfile_updatecli): Separates updatecli pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,3 @@
 buildDockerAndPublishImage('matomo', [
     targetplatforms: 'linux/amd64,linux/arm64',
-    ])
+])

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,3 @@
-parallelDockerUpdatecli([imageName: 'matomo', rebuildImageOnPeriodicJob: false, buildDockerConfig : [targetplatforms: 'linux/amd64,linux/arm64']])
+buildDockerAndPublishImage('matomo', [
+    targetplatforms: 'linux/amd64,linux/arm64',
+    ])

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,16 @@
+final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '10')),
+    disableConcurrentBuilds(abortPrevious: true),
+    pipelineTriggers([cron(cronExpr)]),
+])
+
+timeout(time: 10, unit: 'MINUTES') {
+    final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
+    stage("Run updatecli action: ${updatecliAction}") {
+        updatecli(
+            action: updatecliAction,
+        )
+    }
+}


### PR DESCRIPTION
Pre-requisite: **merge** 

- https://github.com/jenkins-infra/kubernetes-management/pull/6446

As per 
- https://github.com/jenkins-infra/helpdesk/issues/2778

We separate the updatecli pipeline for this repository.