### PR TITLE
chore(Jenkinsfile_updatecli): restore daily cron trigger

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,16 +1,11 @@
 final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
 
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '10')),
-    disableConcurrentBuilds(abortPrevious: true),
-    pipelineTriggers([cron(cronExpr)]),
-])
-
 timeout(time: 10, unit: 'MINUTES') {
     final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
     stage("Run updatecli action: ${updatecliAction}") {
         updatecli(
             action: updatecliAction,
+            cronTriggerExpression: cronExpr,
         )
     }
 }


### PR DESCRIPTION
Superseded by #25.

Branch protection blocked a force-push to keep this to a single commit, so this was re-opened as a fresh PR. See #25 for the actual change.
